### PR TITLE
Clarify GDCC details

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ All three host-guest components of this challenge are now final and launched, th
 - **Release 0.1.1** (July 22, 2019, DOI [10.5281/zenodo.3346023](https://dx.doi.org/10.5281/zenodo.3346023)): Includes updated README files that should have been in release 0.1.
 
 ### Changes not in a release
+- List final (rather than tentative) buffer conditions for GDCC case: Confirming 10 mM sodium phosphate, correcting pH from 11.5 to 11.7
 
 ## Challenge overview
 

--- a/host_guest/GDCC_and_guests/README.md
+++ b/host_guest/GDCC_and_guests/README.md
@@ -18,7 +18,7 @@ In the former they are remote from the non-polar pocket, whilst in the latter th
 ![](../../images/GDCCs.jpg)
 
 The Gibb group will examine the binding of eight guests: four negatively charged, and four positively charged.
-As previously, all binding constants will be determined in sodium phosphate buffer at pH 11.5.
+As previously, all binding constants will be determined in (10 mM) sodium phosphate buffer, here at pH 11.7.
 The guests have been selected to partially overlap with previous determinations for binding to OA (first row of guests; known ITC values to be added to this repository later).
 These six examples will act as a reference point for the other determinations.
 There will be two new determinations for binding to OA (second row of guests), as well as the eight new determinations using new host exo-OA.
@@ -26,13 +26,13 @@ Each of the ten new determinations will be carried out in triplicate using ITC, 
 
 ![](../../images/GDCC_guests.jpg)
 
-Given the identity of these guests, it is likely we will be able to have *some* overlap between the GDCC guests and those used in the modified cyclodextrin (Gilson lab) and acyclic CB (Isaacs lab) portions of the challenge.
+Given the identity of these guests, we will be able to have *some* overlap between the GDCC guests and those used in the modified cyclodextrin (Gilson lab) and acyclic CB (Isaacs lab) portions of the challenge.
 
 ### Additional technical details
 
-Buffer conditions are expected to be 10 mM sodium phosphate, but this will be confirmed as data collection begins. The plan is to gather data in triplicate with fresh solutions of host and guest on each occasion.  Also, all hosts samples are probed by one of either two ways to determine the waters of hydration in each sample.  This can be as high so this analysis is a requirement to avoid bad data.
+Buffer conditions are 10 mM sodium phosphate at pH 11.7. The plan is to gather data in triplicate with fresh solutions of host and guest on each occasion.  Also, all hosts samples are probed by one of either two ways to determine the waters of hydration in each sample.  This can be as high so this analysis is a requirement to avoid bad data.
 
-For positively charged guests, chloride salts are expected to be used.
+For positively charged guests, chloride salts are being used.
 
 ### Disclaimers
 


### PR DESCRIPTION
Removes tentative aspects of buffer conditions and confirms they are 10 mM sodium phosphate; also corrects pH from 11.5 to 11.7 as per Gibb.